### PR TITLE
Fix admin fieldsets

### DIFF
--- a/cmsplugin_slick/admin.py
+++ b/cmsplugin_slick/admin.py
@@ -37,10 +37,9 @@ class SlickCarouselPresetAdmin(admin.ModelAdmin):
             'fields': (
                 'fade',
                 ('rows', 'slides_per_row'),
-                ('center_mode', 'center_padding'),
                 ('variable_width', 'adaptive_height'),
                 ('vertical', 'rigth_to_left'),
-                ('use_theme', 'slick_theme'),
+                'use_theme',
             )
         }),
     )

--- a/cmsplugin_slick/admin.py
+++ b/cmsplugin_slick/admin.py
@@ -25,7 +25,7 @@ class SlickCarouselPresetAdmin(admin.ModelAdmin):
                 ('pause_on_hover', 'pause_on_dots_hover'),
             )
         }),
-        (_('Responce options'), {
+        (_('Response options'), {
             'classes': ('collapse',),
             'fields': (
                 'mobile_first',


### PR DESCRIPTION
Fix of Issue: https://github.com/Atterratio/cmsplugin-slick/issues/4
Solution is to remove duplicated fields in admin's fieldsets configuration.
Related to update of code validation in Django: https://github.com/django/django/pull/9874/files#diff-eb5eeb97b57d294a48985af058477b5f